### PR TITLE
[WEB-629] Fix Security permission exception on Android 4.4 in chat.

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/CameraSender.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/CameraSender.java
@@ -2,6 +2,7 @@ package com.layer.atlas.messagetypes.threepartimage;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.ClipData;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -69,6 +70,12 @@ public class CameraSender extends AttachmentSender {
 
         Intent cameraIntent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
         cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, outputUri);
+        // Temporary permissions for Android <4.2, 5> https://medium.com/@quiro91/sharing-files-through-intents-part-2-fixing-the-permissions-before-lollipop-ceb9bb0eec3a
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            cameraIntent.setClipData(ClipData.newRawUri("", outputUri));
+            cameraIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION |
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        }
 
         activity.startActivityForResult(cameraIntent, ACTIVITY_REQUEST_CODE);
     }


### PR DESCRIPTION
Fix crash
"Crash message: java.lang.SecurityException: Permission Denial: opening provider android.support.v4.content.FileProvider from ProcessRecord
{43bc63c0 940:com.huawei.camera/u0a14}
(pid=940, uid=10014) that is not exported from uid 10119
at com.android.server.am.ActivityManagerService.getContentProviderImpl(ActivityManagerService.java:7885)
at com.android.server.am.ActivityManagerService.getContentProvider(ActivityManagerService.java:8150)
at android.app.ActivityManagerNative.onTransact(ActivityManagerNative.java:704)
at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2223)
at huawei.com.android.server.am.HwActivityManagerService.onTransact(HwActivityManagerService.java:173)
at android.os.Binder.execTransact(Binder.java:404)
at dalvik.system.NativeStart.run(Native Method)"