### PR TITLE
[WEB-1153] Fix crash NoSuchElementException in AvatarTypingIndicatorFactory

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/typingindicators/AvatarTypingIndicatorFactory.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/typingindicators/AvatarTypingIndicatorFactory.java
@@ -116,6 +116,9 @@ public class AvatarTypingIndicatorFactory implements AtlasTypingIndicator.Typing
                         List<AtlasAvatar> newlyFinished = new ArrayList<>();
                         Set<Identity> newlyActives = new HashSet<>(typingUserIds.keySet());
                         for (AtlasAvatar avatar : tag.mActives) {
+                            if (!avatar.getParticipants().keySet().iterator().hasNext())
+                                return;
+
                             String existingTypistKey = avatar.getParticipants().keySet().iterator().next();
                             Identity existingTypist = findTypist(existingTypistKey, typingUserIds.keySet());
                             if (existingTypist == null) {


### PR DESCRIPTION
Caused by: 
`java.util.NoSuchElementException`
`java.util.HashMap$HashIterator.nextEntry`
`java.util.HashMap$KeyIterator.next`

Caused in line: 
`String existingTypistKey = avatar.getParticipants().keySet().iterator().next();`
