### PR TITLE
Fix loading image issue.

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/util/picasso/requesthandlers/MessagePartRequestHandler.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/util/picasso/requesthandlers/MessagePartRequestHandler.java
@@ -45,9 +45,8 @@ public class MessagePartRequestHandler extends com.squareup.picasso.RequestHandl
         Queryable queryable = mLayerClient.get(request.uri);
         if (!(queryable instanceof MessagePart)) return null;
         MessagePart part = (MessagePart) queryable;
-        Source source = Okio.source(part.getDataStream());
-        if (part.isContentReady()) return new Result(source, LoadedFrom.DISK);
+        if (part.isContentReady()) return new Result(Okio.source(part.getDataStream()), LoadedFrom.DISK);
         if (!Util.downloadMessagePart(mLayerClient, part, 3, TimeUnit.MINUTES)) return null;
-        return new Result(source, LoadedFrom.NETWORK);
+        return new Result(Okio.source(part.getDataStream()), LoadedFrom.NETWORK);
     }
 }


### PR DESCRIPTION
Method `Okio.source` throws exception if `InputStream` is null. We have to create source when MessagePart object is downloaded.