### PR TITLE
Don't clear static variables from not static methods.

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/util/imagepopup/AtlasImagePopupActivity.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/util/imagepopup/AtlasImagePopupActivity.java
@@ -155,8 +155,6 @@ public class AtlasImagePopupActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         picasso.cancelTag(mImageView.getTag());
-        layerClient = null;
-        picasso = null;
         mImageView.setTag(null);
         disposable.dispose();
         super.onDestroy();


### PR DESCRIPTION
Fix crash after configuration changed in AtlasImagePopupActivity. We should change static object in non-static methods.